### PR TITLE
feat: fully pathed inputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,9 @@ This Python code is provided as-is and enhancements are welcome. The goal is to 
 
 Uses pipenv for package dependencies. Install pipenv with `pip install pipenv` then run `pipenv install` to install needed packages in virtual environment.
 
-Note: This code has only been tested with Canvas export packages. They need to be unzipped first. All paths are relative, so `cd` to the export directory first, then run main.py to get all paths correct. This will eventually be fixed in the future.
+Note: This code has only been tested with Canvas export packages. They need to be unzipped first.
+
+Specify the input file using either a relative or absolute path. Ensure the path is correctly set based on your current working directory.
 
 
 ## Examples

--- a/src/formats/docx.py
+++ b/src/formats/docx.py
@@ -19,7 +19,12 @@ def write_file(data, outfile):
 
     for assessment in data['assessment']:
         doc.add_heading(assessment['metadata']['title'], 0)
-        html_parser.add_html_to_document(assessment['metadata']['description'], doc)
+
+        # handle error from missing description
+        description = assessment['metadata'].get('description') or ''
+        logger.info("Writing assessment: " + assessment['metadata']['title'])
+        logger.info("with description: " + description)
+        html_parser.add_html_to_document(description, doc)
 
         for question in assessment['question']:
             if 'title' in question:

--- a/src/qti_parser/assessment_meta/__init__.py
+++ b/src/qti_parser/assessment_meta/__init__.py
@@ -5,12 +5,13 @@ Assesment Metadata
 from lxml import etree
 from logzero import logger
 
-def get_metadata(file):
+
+def get_metadata(file_path):
     """ Extracts basic metadata """
     metadata = {}
 
     try:
-        xml = etree.parse(file).getroot()
+        xml = etree.parse(str(file_path)).getroot()
         metadata = {
             'title': xml.find("./{http://canvas.instructure.com/xsd/cccv1p0}title").text,
             'description': xml.find("./{http://canvas.instructure.com/xsd/cccv1p0}description").text,


### PR DESCRIPTION
Hello. I started using `qti-convert` to convert all my canvas quiz banks to markdown so I can manage them with [`text2qti`](https://github.com/gpoore/text2qti) since canvas' quiz management is an abomination.

I noticed the TODO for supporting fully pathed input files and it seemed like a good candidate for my first ever pull request. So here we are. I hope I didn't break anything! I tested that it works with the provided test case and my own with a variety of options.