### PR TITLE
Feature: Functionality to output quiz in a gradescope compatible format.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -35,7 +35,8 @@ MANIFEST
 # Test and output folders
 cases/
 *.docx
-
+*.json
+*.txt
 
 # PyInstaller
 #  Usually these files are written by a python script from a template

--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,11 @@ share/python-wheels/
 *.egg
 MANIFEST
 
+# Test and output folders
+cases/
+*.docx
+
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/src/formats/__init__.py
+++ b/src/formats/__init__.py
@@ -3,3 +3,4 @@ Output Formats
 """
 
 from . import docx
+from . import gradescope

--- a/src/formats/gradescope.py
+++ b/src/formats/gradescope.py
@@ -1,0 +1,91 @@
+"""
+Gradescope-compatible plain text format
+"""
+
+from html.parser import HTMLParser
+from docx import Document
+
+
+class _StripHTML(HTMLParser):
+    def __init__(self):
+        super().__init__()
+        self._parts = []
+
+    def handle_data(self, data):
+        self._parts.append(data)
+
+    def get_text(self):
+        return ''.join(self._parts).strip()
+
+
+def _strip_html(html_text):
+    if not html_text:
+        return ''
+    parser = _StripHTML()
+    parser.feed(html_text)
+    return parser.get_text()
+
+
+def write_file(data, outfile=None):
+    lines = []
+    q_num = 1
+
+    for assessment in data['assessment']:
+        for question in assessment['question']:
+            q_type = question.get('question_type', '')
+            q_text = _strip_html(question.get('text', ''))
+
+            lines.append(f"{q_num}. {q_text}")
+
+            if 'answer' in question:
+                for answer in question['answer']:
+                    if not answer.get('display', True):
+                        continue
+                    text = _strip_html(answer.get('text', ''))
+                    correct = answer.get('correct', False)
+
+                    if q_type == 'true_false_question':
+                        marker = '[*]' if correct else '[ ]'
+                    else:
+                        marker = '[x]' if correct else '[ ]'
+
+                    lines.append(f"{marker} {text}")
+
+            lines.append('')
+            q_num += 1
+
+    output = '\n'.join(lines)
+
+    if outfile:
+        with open(outfile, 'w', encoding='utf-8') as f:
+            f.write(output)
+    else:
+        print(output)
+
+
+def write_docx(data, outfile):
+    lines = []
+    q_num = 1
+
+    for assessment in data['assessment']:
+        for question in assessment['question']:
+            q_type = question.get('question_type', '')
+            q_text = _strip_html(question.get('text', ''))
+            lines.append(f"{q_num}. {q_text}")
+
+            if 'answer' in question:
+                for answer in question['answer']:
+                    if not answer.get('display', True):
+                        continue
+                    text = _strip_html(answer.get('text', ''))
+                    correct = answer.get('correct', False)
+                    marker = '[*]' if (q_type == 'true_false_question' and correct) else ('[x]' if correct else '[ ]')
+                    lines.append(f"{marker} {text}")
+
+            lines.append('')
+            q_num += 1
+
+    doc = Document()
+    for line in lines:
+        doc.add_paragraph(line)
+    doc.save(outfile)

--- a/src/main.py
+++ b/src/main.py
@@ -56,14 +56,10 @@ def main(args):
             qti_resource['assessment'].append(this_assessment)
 
         if args.format.lower() == "json":
-            if args.output:
-                logger.info("Writing JSON to '" + args.output + "'...")
-                with open(args.output, 'w') as outfile:
-                    json.dump(qti_resource, outfile)
-            else:
-                logger.info("Writing JSON to STDOUT...")
-                qti_resource_json = json.dumps(qti_resource, indent = 2)
-                print(qti_resource_json)
+            outfile = args.output or "output.json"
+            logger.info("Writing JSON to '" + outfile + "'...")
+            with open(outfile, 'w') as f:
+                json.dump(qti_resource, f, indent=2)
 
         elif args.format.lower() == "docx":
             if args.output:
@@ -72,6 +68,15 @@ def main(args):
                 outfile = "output.docx"
             logger.info("Writing DOCX to '" + outfile + "'...")
             formats.docx.write_file(qti_resource, outfile)
+
+        elif args.format.lower() == "gradescope":
+            if args.output and args.output.lower().endswith(".docx"):
+                logger.info("Writing Gradescope DOCX to '" + args.output + "'...")
+                formats.gradescope.write_docx(qti_resource, args.output)
+            else:
+                outfile = args.output or "output.txt"
+                logger.info("Writing Gradescope format to '" + outfile + "'...")
+                formats.gradescope.write_file(qti_resource, outfile)
 
         elif args.format.lower() == "pdf":
             logger.error("Format not supported yet: " + args.format)
@@ -90,7 +95,7 @@ if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Convert QTI files into other formats.", add_help=False)
     parser.add_argument("input", help="QTI input file (imsmanifest.xml).")
     parser.add_argument("-v", action="count", default=0, help="Verbosity (-v, -vv, etc).")
-    parser.add_argument("-f", action="store", dest="format", default="json", help="Output format, defaults to JSON.")
+    parser.add_argument("-f", action="store", dest="format", default="json", help="Output format: json, docx, gradescope. Defaults to JSON.")
     parser.add_argument("-o", action="store", dest="output", help="Output file.")
     parser.add_argument( "--version", action="version", help="Display version and exit.", version="%(prog)s (version {version})".format(version=__version__))
     parser.add_argument('-h', '--help', action='help', default=argparse.SUPPRESS, help='Show this help message and exit.')


### PR DESCRIPTION
Reason: There is no available API's or interface to import qti canvas quiz into gradescope automatically.

Changes Include:

1. Convert exam quiz from a QTI export file to a gradescope compatible format (particularly the new online assignment format) for easier.
2. The output is of 2 types Docx format and txt format


Future work:

1. Resolve issues with image not being uploaded into docx.
2. Handle external images in a better way.